### PR TITLE
ci: fix npm ci lockfile drift between npm 10 and npm 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version: [22.x, 24.x]
     steps:
@@ -11,6 +12,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      # Node 22 ships npm 10, Node 24 ships npm 11, and the two resolve optional
+      # peer dependencies differently. Pin npm so every leg agrees with the
+      # lockfile Dependabot writes.
+      - run: npm i -g npm@11
       - run: npm ci
       - run: npm run lint
       - run: npm test
@@ -31,6 +36,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24.x
+      - run: npm i -g npm@11
       - run: npm ci
       - run: npx semantic-release
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -426,6 +426,37 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/@commitlint/read/node_modules/conventional-commits-filter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
+      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@commitlint/read/node_modules/conventional-commits-parser": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.2.tgz",
+      "integrity": "sha512-O+x4N2yH+ijvqWlIyTHsXTAP+algNWgGbjY2duCe8w2vUMvUB95cLRslCPfTMQyLAKlet3bhZTdu6ozn4M+QJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^2.0.0",
+        "argue-cli": "^3.1.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@commitlint/resolve-extends": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.2.0.tgz",


### PR DESCRIPTION
## Problem

Every push to `main` since #273 has failed at the **`npm ci`** step of `test (22.x)`, before lint or tests run:

```
npm error `npm ci` can only install packages when your package.json and
package-lock.json are in sync.
npm error Missing: conventional-commits-filter@6.0.1 from lock file
npm error Missing: conventional-commits-parser@7.1.2 from lock file
```

`test (24.x)` was only ever *cancelled* by matrix fail-fast, and `release` is gated on `needs: test` — so **semantic-release has not published since #272**.

## Root cause

An npm-version split, not a genuinely corrupt lockfile.

Bisected to `4312b1f` (`chore(deps-dev): bump @commitlint/cli 21.0.2 → 21.2.1`, #273). That bump pulled in `@commitlint/read` → `@conventional-changelog/git-client@3.1.0`, which declares **optional peer dependencies** on `conventional-commits-filter@^6.0.1` and `conventional-commits-parser@^7.0.1`.

- **npm 11** — what Dependabot used to write the lock — skips optional peers entirely and omits them from the tree.
- **npm 10** installs them, so it reads the lockfile as missing two packages and refuses.

The Node **22.x** runner ships npm **10.9.x**; Node **24.x** ships npm **11.x**. Hence only the 22.x leg failed.

Reproduced precisely: `npx npm@10 ci` on `main` fails with the identical error, while `npm@11 ci` succeeds.

## Changes

1. **Regenerated `package-lock.json` with npm 10** so it carries both optional peers. 31 lines, purely additive — two entries nested under `node_modules/@commitlint/read/node_modules/`, both marked `"optional": true, "peer": true`. **No dependency versions change.** The result is a superset that npm 10 and npm 11 both accept.
2. **Pinned `npm@11`** before `npm ci` in the `test` and `release` jobs, so every leg resolves identically to the lockfile Dependabot writes. This is the durable fix — regenerating the lock alone would let the next Dependabot PR touching optional peers reintroduce the drift.
3. **`fail-fast: false`** on the test matrix, so a 22.x failure no longer cancels 24.x and hides its signal — that cost real diagnostic information here.

## Verification

- Clean `npm ci` passes under **npm 10.9.9** and **npm 11.16.0** (the previously failing npm 10 case now succeeds)
- `npm run lint` clean
- 32/32 tests passing

## Notes

Commit type is `ci:` deliberately — under the angular preset only `feat`/`fix`/`perf` trigger a release, so this won't cut a version bump itself. It **will** unblock the `release` job, which has been skipped since #272, so merging may publish whatever releasable commits queued up behind the breakage. Worth a glance at `git log` first if you'd rather control that timing.

Not included: `engines.node` still says `>=18` (package.json:34) while CI tests 22/24 and several dev deps require `>=22`. Raising it is semver-meaningful for consumers, so it belongs in its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)