### PR TITLE
fix(sources): signal when cached input finishes writing its cache file

### DIFF
--- a/lib/sources/cached_input.js
+++ b/lib/sources/cached_input.js
@@ -1,4 +1,5 @@
 const {Readable} = require('stream');
+const {finished} = require('stream/promises');
 const {config} = require('../config');
 const fs = require('fs');
 
@@ -28,6 +29,16 @@ module.exports = class CachedInput extends Readable {
     }
     if (this.output) {
       this.pipe(this.output);
+      // Consumers reach 'end' as soon as the data is read, but the cache file
+      // is opened truncated and may still be buffered at that point. Await this
+      // to know the cache file is complete on disk. Write failures surface on
+      // the 'error' event, matching how input failures are reported below.
+      this.cacheWritten = finished(this.output).catch((err) => {
+        this.emit('error', err);
+      });
+    } else {
+      // Reading from an existing cache: nothing is written.
+      this.cacheWritten = Promise.resolve();
     }
   }
   _read(_size) {

--- a/lib/sources/index.js
+++ b/lib/sources/index.js
@@ -2,7 +2,7 @@ const CsvSource = require('./csv_source');
 const JsonSource = require('./json_source');
 const StaticSetSource = require('./static_set_source');
 const PaginatedHttpInput = require('./paginated_http_input');
-const CachedInput = require('./paginated_http_input');
+const CachedInput = require('./cached_input');
 const MultipleHttpInput = require('./multiple_http_input');
 const XmlSource = require('./xml_source');
 

--- a/test/src/cached_source_test.js
+++ b/test/src/cached_source_test.js
@@ -21,12 +21,14 @@ describe('cached source', function() {
     let source = new CsvSource({siteMap: {changefreq: 'foo', priority: 1, channel: 'csv',
       urlFormatter: this.urlFormatter}, input: {cached: {cacheFile: this.cacheFile, maxAge: 86000000}, fileName: `${process.cwd()}/test/config/test.csv`}}).
       on('end', () => {
-        expect(urls.length).to.equal(5);
-        expect(urls[0].url).to.equal('http://test.com/url1');
-        expect(urls[1].url).to.equal('http://test.com/url2');
-        expect(urls[1].imageUrl).to.equal('/image2');
-        expect(fs.existsSync(this.cacheFile));
-        done();
+        source.inputStream.cacheWritten.then(() => {
+          expect(urls.length).to.equal(5);
+          expect(urls[0].url).to.equal('http://test.com/url1');
+          expect(urls[1].url).to.equal('http://test.com/url2');
+          expect(urls[1].imageUrl).to.equal('/image2');
+          expect(fs.existsSync(this.cacheFile)).to.be.true;
+          done();
+        }).catch(done);
       }).on('error', (err) => {
         console.log("ERROR: ", err);
         console.log(err.stack);
@@ -51,7 +53,7 @@ describe('cached source', function() {
           expect(urls[0].url).to.equal('http://test.com/url1_cached');
           expect(urls[1].url).to.equal('http://test.com/url2_cached');
           expect(urls[1].imageUrl).to.equal('/image2_cached');
-          expect(fs.existsSync(this.cacheFile));
+          expect(fs.existsSync(this.cacheFile)).to.be.true;
           expect(fs.statSync(this.cacheFile).size).to.be.above(0);
           done();
         }).on('error', (err) => {
@@ -75,13 +77,17 @@ describe('cached source', function() {
       let source = new CsvSource({siteMap: {changefreq: 'foo', priority: 1, channel: 'csv',
         urlFormatter: this.urlFormatter}, input: {cached: {cacheFile: this.cacheFile, maxAge: 86000000}, fileName: `${process.cwd()}/test/config/test.csv`}}).
         on('end', () => {
-          expect(urls.length).to.equal(5);
-          expect(urls[0].url).to.equal('http://test.com/url1');
-          expect(urls[1].url).to.equal('http://test.com/url2');
-          expect(urls[1].imageUrl).to.equal('/image2');
-          expect(fs.existsSync(this.cacheFile));
-          expect(fs.statSync(this.cacheFile).size).to.be.above(0);
-          done();
+          // The cache file is reopened truncated, so its size is only
+          // meaningful once the rewrite has flushed to disk.
+          source.inputStream.cacheWritten.then(() => {
+            expect(urls.length).to.equal(5);
+            expect(urls[0].url).to.equal('http://test.com/url1');
+            expect(urls[1].url).to.equal('http://test.com/url2');
+            expect(urls[1].imageUrl).to.equal('/image2');
+            expect(fs.existsSync(this.cacheFile)).to.be.true;
+            expect(fs.statSync(this.cacheFile).size).to.be.above(0);
+            done();
+          }).catch(done);
         }).on('error', (err) => {
           console.log("ERROR: ", err);
           console.log(err.stack);
@@ -105,13 +111,17 @@ describe('cached source', function() {
       let source = new CsvSource({siteMap: {changefreq: 'foo', priority: 1, channel: 'csv',
         urlFormatter: this.urlFormatter}, input: {cached: {cacheFile: this.cacheFile, maxAge: 86000000}, fileName: `${process.cwd()}/test/config/test.csv`}}).
         on('end', () => {
-          expect(urls.length).to.equal(5);
-          expect(urls[0].url).to.equal('http://test.com/url1');
-          expect(urls[1].url).to.equal('http://test.com/url2');
-          expect(urls[1].imageUrl).to.equal('/image2');
-          expect(fs.existsSync(this.cacheFile));
-          expect(fs.statSync(this.cacheFile).size).to.be.above(0);
-          done();
+          // The cache file is reopened truncated, so its size is only
+          // meaningful once the rewrite has flushed to disk.
+          source.inputStream.cacheWritten.then(() => {
+            expect(urls.length).to.equal(5);
+            expect(urls[0].url).to.equal('http://test.com/url1');
+            expect(urls[1].url).to.equal('http://test.com/url2');
+            expect(urls[1].imageUrl).to.equal('/image2');
+            expect(fs.existsSync(this.cacheFile)).to.be.true;
+            expect(fs.statSync(this.cacheFile).size).to.be.above(0);
+            done();
+          }).catch(done);
         }).on('error', (err) => {
           console.log("ERROR: ", err);
           console.log(err.stack);


### PR DESCRIPTION
Follow-up to #281, which fixed `npm ci` and set `fail-fast: false`. That immediately exposed a pre-existing flake on the 24.x leg, which had been permanently hidden because 22.x failed first and cancelled it.

## The race

`CachedInput` opens the cache file truncated (`fs.createWriteStream`) and pipes itself into it, but **nothing ever awaited that write stream**. Consumers reach `end` as soon as the data has been *read*, which can be before the rewrite has *flushed*. In that window the cache file exists but is still 0 bytes.

That surfaced on CI as:

```
1) cached source with existing expired cache data reads uncached data:
   Uncaught AssertionError: expected +0 to be above +0
   at CsvSource.<anonymous> (test/src/cached_source_test.js:113:58)
```

It's also a real gap in the library, not just a test bug: there was no way for a consumer to know when the cache file was safe to read.

## Changes

- **Expose `CachedInput#cacheWritten`** — a promise that settles once the cache file is complete on disk, resolved immediately when reading an existing cache (nothing is written). Write failures now surface on the `'error'` event instead of going unobserved, matching how input failures were already reported.
- **Await it in the two tests that assert on cache file size.** Both the zero-length and expired-cache cases had the identical race — only the expired one happened to fail on CI, so fixing just the reported line would have left an equally flaky test behind.
- **Fix three no-op assertions.** `expect(fs.existsSync(f))` with no matcher asserts nothing; now `.to.be.true`.
- **Fix `lib/sources/index.js` exporting the wrong class.** Line 5 was a copy-paste of line 4, so `CachedInput` was exported as `PaginatedHttpInput` and the real `CachedInput` was unreachable from the package index. Nothing in-repo broke (it's reached internally via `sitemap_transformer.js`), but `require('site-mapper').CachedInput` gave consumers the wrong class.

## Verification

- `npm run lint` clean, **32/32 tests passing**
- `CachedInput` and `PaginatedHttpInput` confirmed as distinct exports
- `cacheWritten` confirmed to resolve with the cache file fully written

One caveat worth stating plainly: **I could not reproduce the original timing gap on local disk** — not with the test fixtures, nor with a 200k-row input. It only manifested on the CI runner. The fix is correct by construction (it awaits Node's documented `finish` guarantee via `stream/promises.finished`) rather than by reproduction, so the honest claim is that the assertion can no longer run before the flush, not that I watched it fail and then pass.

## Release note

This is typed `fix:`, so it **will** cut a patch release on merge — intended, since the wrong-export bug is consumer-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)