### PR TITLE
fix(cli): repair bin/sitemapper and its config overrides

### DIFF
--- a/bin/sitemapper
+++ b/bin/sitemapper
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
-var argv = require('yargs').
+// yargs 18 dropped the CommonJS singleton: require('yargs') is the factory, so
+// it has to be called with the args rather than chained off directly.
+var argv = require('yargs')(process.argv.slice(2)).
   usage('Usage: $0 [-s SITEMAP] [-i INCLUDES] [-e EXCLUDES]').
   describe('s', 'name of the sitemap in the sitemaps section of the configuration file').
   describe('i', 'only include specified source(s)').
@@ -44,16 +46,16 @@ var addExcludes = function() {
     return;
   }
   setupSitemapOverride();
-  if (!overrides.sitemaps[argv.s].excludes) {
-    overrides.sitemaps[argv.s].excludes = [];
+  // SiteMapper reads excludes from sitemapConfig.sources.excludes.
+  if (!overrides.sitemaps[argv.s].sources.excludes) {
+    overrides.sitemaps[argv.s].sources.excludes = [];
   }
-  overrides.sitemaps[argv.s].sources.excludes.apply('push', argv.e);
+  overrides.sitemaps[argv.s].sources.excludes.push.apply(
+    overrides.sitemaps[argv.s].sources.excludes, argv.e);
 };
 
 setIncludes();
 addExcludes();
-
-console.log("OVERRIDES: ", overrides);
 
 generateSitemaps(overrides, function(err) {
   if (err) {

--- a/bin/sitemapper
+++ b/bin/sitemapper
@@ -20,19 +20,28 @@ var argv = require('yargs')(process.argv.slice(2)).
 
 // set environment
 process.env.NODE_ENV = process.env.NODE_ENV || 'production';
-var generateSitemaps = require('../lib/main').generateSitemaps;
+var main = require('../lib/main');
+var generateSitemaps = main.generateSitemaps;
+var config = main.config;
 var overrides = {};
 
+// config.addOverrides replaces top level keys wholesale, which is what a caller
+// building a one-off sitemap wants. These flags mean the opposite -- they name a
+// sitemap in the config file and adjust its sources -- so the override has to be
+// seeded from the configured sitemap, or its own settings are dropped.
 var setupSitemapOverride = function() {
-  if (!overrides.sitemaps) {
-    overrides.sitemaps = {};
+  if (overrides.sitemaps) {
+    return;
   }
-  if (!overrides.sitemaps[argv.s]) {
-    overrides.sitemaps[argv.s] = { };
+  config.addAppSpecific();
+  var configured = config.sitemaps && config.sitemaps[argv.s];
+  if (!configured) {
+    console.error(`No sitemap named '${argv.s}' in the configuration`);
+    process.exit(1);
   }
-  if (!overrides.sitemaps[argv.s].sources) {
-    overrides.sitemaps[argv.s].sources = { };
-  }
+  overrides.sitemaps = {};
+  overrides.sitemaps[argv.s] = Object.assign({}, configured);
+  overrides.sitemaps[argv.s].sources = Object.assign({}, configured.sources);
 };
 var setIncludes = function() {
   if (!argv.i) {
@@ -46,12 +55,10 @@ var addExcludes = function() {
     return;
   }
   setupSitemapOverride();
-  // SiteMapper reads excludes from sitemapConfig.sources.excludes.
-  if (!overrides.sitemaps[argv.s].sources.excludes) {
-    overrides.sitemaps[argv.s].sources.excludes = [];
-  }
-  overrides.sitemaps[argv.s].sources.excludes.push.apply(
-    overrides.sitemaps[argv.s].sources.excludes, argv.e);
+  // SiteMapper reads excludes from sitemapConfig.sources.excludes. Copy any
+  // configured excludes rather than pushing onto the config's own array.
+  var sources = overrides.sitemaps[argv.s].sources;
+  sources.excludes = (sources.excludes || []).concat(argv.e);
 };
 
 setIncludes();

--- a/test/src/cli_test.js
+++ b/test/src/cli_test.js
@@ -66,4 +66,25 @@ describe('sitemapper cli', function() {
       done();
     });
   });
+  // The flags name a sitemap in the config file, so they have to keep that
+  // sitemap's own settings -- addOverrides would otherwise replace them.
+  it('keeps the configured sitemap settings', (done) => {
+    runCli(['-s', 'test.com', '-e', 'source2'], (err) => {
+      if (err) { return done(err); }
+      const files = generatedFiles();
+      // sitemapIndex: 'testSitemap.xml', not the default sitemap.xml
+      expect(files).to.contain('testSitemap.xml');
+      // maxUrlsPerFile: 2 over source1's 4 urls
+      expect(files.filter((f) => f.startsWith('channel1')).length).to.equal(2);
+      done();
+    });
+  });
+  it('fails cleanly on an unknown sitemap name', (done) => {
+    runCli(['-s', 'nosuchsitemap', '-i', 'source1'], (err, stdout, stderr) => {
+      expect(err).to.not.be.null;
+      expect(err.code).to.equal(1);
+      expect(stderr).to.contain('nosuchsitemap');
+      done();
+    });
+  });
 });

--- a/test/src/cli_test.js
+++ b/test/src/cli_test.js
@@ -1,0 +1,69 @@
+const {expect} = require('chai');
+const {execFile} = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const cli = path.join(process.cwd(), 'bin', 'sitemapper');
+const targetDir = path.join(process.cwd(), 'tmp', 'sitemaps', 'test');
+
+// The CLI is a separate entry point from the library, so it only gets covered
+// by actually running it. A require-time failure in bin/sitemapper shipped in
+// three releases because nothing here spawned it.
+const runCli = (args, done) => {
+  execFile(process.execPath, [cli].concat(args), {
+    cwd: process.cwd(),
+    env: Object.assign({}, process.env, {
+      CONFIG_DIR: path.join(process.cwd(), 'test'),
+      NODE_ENV: 'test'
+    }),
+    timeout: 30000
+  }, done);
+};
+
+const generatedFiles = () => {
+  return fs.existsSync(targetDir) ? fs.readdirSync(targetDir).sort() : [];
+};
+
+describe('sitemapper cli', function() {
+  this.timeout(30000);
+  beforeEach( () => {
+    fs.rmSync(targetDir, {recursive: true, force: true});
+  });
+  it('loads and prints usage', (done) => {
+    runCli(['--help'], (err, stdout) => {
+      if (err) { return done(err); }
+      expect(stdout).to.contain('Usage:');
+      expect(stdout).to.contain('--sitemap');
+      expect(stdout).to.contain('--include');
+      expect(stdout).to.contain('--exclude');
+      done();
+    });
+  });
+  it('generates sitemaps with no arguments', (done) => {
+    runCli([], (err) => {
+      if (err) { return done(err); }
+      const files = generatedFiles();
+      expect(files).to.contain('channel10.xml.gz');
+      expect(files).to.contain('channel20.xml.gz');
+      done();
+    });
+  });
+  it('restricts sources with --include', (done) => {
+    runCli(['-s', 'test.com', '-i', 'source1'], (err) => {
+      if (err) { return done(err); }
+      const files = generatedFiles();
+      expect(files.some((f) => f.startsWith('channel1'))).to.be.true;
+      expect(files.some((f) => f.startsWith('channel2'))).to.be.false;
+      done();
+    });
+  });
+  it('drops sources with --exclude', (done) => {
+    runCli(['-s', 'test.com', '-e', 'source2'], (err) => {
+      if (err) { return done(err); }
+      const files = generatedFiles();
+      expect(files.some((f) => f.startsWith('channel1'))).to.be.true;
+      expect(files.some((f) => f.startsWith('channel2'))).to.be.false;
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## The CLI throws on every invocation

```
$ npx site-mapper --help
TypeError: require(...).usage is not a function
    at bin/sitemapper:4:3
```

**Cause:** `chore(deps): bump yargs from 17.7.2 to 18.0.0` (`4afba72`). yargs 18 went ESM-first and dropped the CommonJS singleton — `require('yargs')` is now the *factory function*, not an instance, so `.usage()` doesn't exist:

```js
> typeof require('yargs')   // 'function'
> require('yargs').usage    // undefined
```

**This is in `v4.0.1`, `v4.1.0` and `v4.1.1`.** `package.json` declares `"bin": {"site-mapper": "bin/sitemapper"}` with no `files` restriction, so the broken binary is in every published tarball. CI stayed green because **nothing in the suite ever spawned the CLI** — all 32 tests exercised the library directly.

## Changes

1. **Call the yargs factory** with the args rather than chaining off the module.
2. **Fix `--exclude`**, which had a second bug hiding behind the first. `bin/sitemapper:47` guarded `sitemaps[s].excludes` while line 50 wrote to `sitemaps[s].sources.excludes` — different paths, so it threw `Cannot read properties of undefined (reading 'apply')`. `SiteMapper` reads `sources.excludes` (`lib/site_mapper.js:46`), so the *guard* was on the wrong path. `.excludes.apply('push', argv.e)` also had receiver and method swapped. `-e` has never worked in this form.
3. **Drop a leftover** `console.log("OVERRIDES: ", overrides)` debug line.

## Keeping the configured sitemap's settings

`-s` names a sitemap **in the configuration file** and `-i/-e` adjust its sources — but the CLI passed `addOverrides` a bare partial, so that sitemap's own settings were dropped:

| | index file | files |
|---|---|---|
| before | `sitemap.xml` | 1 |
| after | `testSitemap.xml` | 2 (`maxUrlsPerFile: 2` honored) |

To be clear about where the fault was: **`config.addOverrides` is correct and is unchanged.** Replacing top-level keys wholesale is deliberate — it lets a caller drive a one-off custom sitemap while ignoring the config file's `sitemaps`, and `generator_test.js:61` asserts exactly that (it passes the same shape and expects `maxUrlsPerFile` to be discarded). The CLI was misusing a correctly-designed API against its own documented intent.

- Seed the override from `config.sitemaps[argv.s]` after `addAppSpecific()`, copying the sitemap and its sources rather than starting from `{}`.
- Make `-e` genuinely additive as its help text promises ("**add** specified source(s) to excludes"), concatenating onto any configured excludes instead of replacing them — without mutating the config's array.
- Exit 1 with a clear message when `-s` names a sitemap that isn't configured. Previously it generated an empty sitemap silently.

## Test coverage

`test/src/cli_test.js` spawns the real binary. Suite goes 32 → 38.

Every test was verified to fail against the code it covers, not merely to pass:

| Scenario | Result |
|---|---|
| Pre-fix binary | all 4 original CLI tests fail |
| Only the `--exclude` path bug reintroduced | that test fails, other 3 pass |
| Only the bare-partial override reintroduced | the 2 new tests fail, other 4 pass |

The isolation rows matter: against the pre-fix binary everything dies at line 4, which would mask the other two bugs entirely.

`npm run lint` clean, **38/38 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

