### PR TITLE
feat: replace yargs with util.parseArgs and require node >= 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,10 @@ Usage: node_modules/.bin/site-mapper [-s SITEMAP] [-i INCLUDES] [-e EXCLUDES]
 
 Options:
   -s, --sitemap  name of the sitemap in the sitemaps section of the config file
-  -i, --include  only include specified source(s)                        [array]
-  -e, --exclude  add specified source(s) to excludes                     [array]
-  -h, --help     Show help                                             [boolean]
+  -i, --include  only include specified source(s)                        [list]
+  -e, --exclude  add specified source(s) to excludes                     [list]
+  -h, --help     Show help                                            [boolean]
+      --version  Show version number                                  [boolean]
 ```
 
 Using the configuration above, to generate the sitemap(s) for just the
@@ -208,6 +209,16 @@ Using the configuration above, to generate the sitemap(s) for just the
 ```bash
 NODE_ENV=staging ./node_modules/.bin/site-mapper -s main -i staticUrls
 ```
+
+`-i` and `-e` take more than one source, either repeated or comma separated:
+
+```bash
+NODE_ENV=staging ./node_modules/.bin/site-mapper -s main -i staticUrls -i products
+NODE_ENV=staging ./node_modules/.bin/site-mapper -s main -i staticUrls,products
+```
+
+The named sitemap keeps the settings it has in the configuration file; `-i`
+replaces its list of included sources and `-e` adds to its excludes.
 
 ## Sitemap Generation ##
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Site Map Generation in node.js
 
 ## Requirements ##
 
-Node.js >= 18
+Node.js >= 22
 
 ## Installation ##
 
@@ -15,7 +15,7 @@ of a package.json file:
 ```json
 {
   "dependencies": {
-    "site-mapper": ">= 4.0.0"
+    "site-mapper": ">= 5.0.0"
   }
 }
 ```
@@ -37,10 +37,10 @@ Create a package.json file similar to the following:
   "description": "sitemap generation for mysite.com",
   "version": "1.0.0",
   "dependencies": {
-    "site-mapper": ">= 4.0.0"
+    "site-mapper": ">= 5.0.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   }
 }
 ```

--- a/bin/sitemapper
+++ b/bin/sitemapper
@@ -1,22 +1,66 @@
 #!/usr/bin/env node
 
-// yargs 18 dropped the CommonJS singleton: require('yargs') is the factory, so
-// it has to be called with the args rather than chained off directly.
-var argv = require('yargs')(process.argv.slice(2)).
-  usage('Usage: $0 [-s SITEMAP] [-i INCLUDES] [-e EXCLUDES]').
-  describe('s', 'name of the sitemap in the sitemaps section of the configuration file').
-  describe('i', 'only include specified source(s)').
-  describe('e', 'add specified source(s) to excludes').
-  help('h').
-  array('i').
-  array('e').
-  alias('h', 'help').
-  alias('s', 'sitemap').
-  alias('i', 'include').
-  alias('e', 'exclude').
-  implies('i', 's').
-  implies('e', 's').
-  argv;
+var {parseArgs} = require('util');
+
+var usage = [
+  'Usage: site-mapper [-s SITEMAP] [-i INCLUDES] [-e EXCLUDES]',
+  '',
+  'Options:',
+  '  -s, --sitemap  name of the sitemap in the sitemaps section of the config file',
+  '  -i, --include  only include specified source(s)                        [list]',
+  '  -e, --exclude  add specified source(s) to excludes                     [list]',
+  '  -h, --help     Show help                                            [boolean]',
+  '      --version  Show version number                                  [boolean]',
+  '',
+  'Repeat -i/-e or separate values with commas:',
+  '  -i source1 -i source2      -i source1,source2'
+].join('\n');
+
+var fail = function(message) {
+  console.error(`${message}\n\n${usage}`);
+  process.exit(1);
+};
+
+var values;
+try {
+  values = parseArgs({
+    options: {
+      sitemap: {type: 'string', short: 's'},
+      include: {type: 'string', short: 'i', multiple: true},
+      exclude: {type: 'string', short: 'e', multiple: true},
+      help: {type: 'boolean', short: 'h'},
+      version: {type: 'boolean'}
+    }
+  }).values;
+} catch (err) {
+  fail(err.message);
+}
+
+if (values.help) {
+  console.log(usage);
+  process.exit(0);
+}
+if (values.version) {
+  console.log(require('../package.json').version);
+  process.exit(0);
+}
+
+// parseArgs collects repeated flags but, unlike the yargs array type, will not
+// swallow bare words after one. Splitting on commas keeps multi-value usable.
+var list = function(vals) {
+  if (!vals) {
+    return undefined;
+  }
+  var flat = vals.reduce(function(acc, val) {
+    return acc.concat(val.split(',').map((v) => v.trim()).filter((v) => v.length > 0));
+  }, []);
+  return flat.length > 0 ? flat : undefined;
+};
+
+var argv = {s: values.sitemap, i: list(values.include), e: list(values.exclude)};
+if ((argv.i || argv.e) && !argv.s) {
+  fail('Missing dependent arguments: -i and -e both require -s');
+}
 
 // set environment
 process.env.NODE_ENV = process.env.NODE_ENV || 'production';

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "csv": "^6.3.1",
         "pino": "^10.3.1",
         "sax": "^1.2.4",
-        "stream-json": "^2.0.0",
-        "yargs": "^18.0.0"
+        "stream-json": "^2.0.0"
       },
       "bin": {
         "site-mapper": "bin/sitemapper"
@@ -1676,6 +1675,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2311,6 +2311,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
       "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^7.2.0",
@@ -2325,6 +2326,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2337,12 +2339,14 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^10.3.0",
@@ -2360,6 +2364,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -2375,6 +2380,7 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
       "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
@@ -3349,6 +3355,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4006,6 +4013,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -4015,6 +4023,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10262,6 +10271,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -10281,6 +10291,7 @@
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
       "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^9.0.1",
@@ -10334,12 +10345,14 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^10.3.0",
@@ -10357,6 +10370,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -10372,6 +10386,7 @@
       "version": "22.0.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
       "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "csv": "^6.3.1",
     "pino": "^10.3.1",
     "sax": "^1.2.4",
-    "stream-json": "^2.0.0",
-    "yargs": "^18.0.0"
+    "stream-json": "^2.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^21.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "sitemap"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "dependencies": {
     "csv": "^6.3.1",

--- a/test/src/cli_test.js
+++ b/test/src/cli_test.js
@@ -79,6 +79,47 @@ describe('sitemapper cli', function() {
       done();
     });
   });
+  it('prints the version', (done) => {
+    runCli(['--version'], (err, stdout) => {
+      if (err) { return done(err); }
+      expect(stdout.trim()).to.equal(require('../../package.json').version);
+      done();
+    });
+  });
+  it('accepts comma separated list values', (done) => {
+    runCli(['-s', 'test.com', '-i', 'source1,source2'], (err) => {
+      if (err) { return done(err); }
+      const files = generatedFiles();
+      expect(files.some((f) => f.startsWith('channel1'))).to.be.true;
+      expect(files.some((f) => f.startsWith('channel2'))).to.be.true;
+      done();
+    });
+  });
+  it('accepts repeated list flags', (done) => {
+    runCli(['-s', 'test.com', '-i', 'source1', '-i', 'source2'], (err) => {
+      if (err) { return done(err); }
+      const files = generatedFiles();
+      expect(files.some((f) => f.startsWith('channel1'))).to.be.true;
+      expect(files.some((f) => f.startsWith('channel2'))).to.be.true;
+      done();
+    });
+  });
+  it('requires --sitemap alongside --include', (done) => {
+    runCli(['-i', 'source1'], (err, stdout, stderr) => {
+      expect(err).to.not.be.null;
+      expect(err.code).to.equal(1);
+      expect(stderr).to.contain('require -s');
+      done();
+    });
+  });
+  it('rejects unknown options', (done) => {
+    runCli(['--nosuchflag'], (err, stdout, stderr) => {
+      expect(err).to.not.be.null;
+      expect(err.code).to.equal(1);
+      expect(stderr).to.contain('nosuchflag');
+      done();
+    });
+  });
   it('fails cleanly on an unknown sitemap name', (done) => {
     runCli(['-s', 'nosuchsitemap', '-i', 'source1'], (err, stdout, stderr) => {
       expect(err).to.not.be.null;


### PR DESCRIPTION
`yargs` existed for three flags and a help screen. Node's built-in `util.parseArgs` covers that, and dropping it removes the dependency that broke the CLI outright at the 18.0.0 bump (see #284).

## Impact

**Consumer installs drop from 37 production packages to 21** — 16 removed. `--help` also stops paying to load yargs (~119ms → ~38ms in the test suite).

`yargs` remains in the lockfile as a **dev-only** transitive (semantic-release and commitlint depend on it), so `npm ci` for development is unchanged. Only what consumers install shrinks.

## Behavior

Preserved: `-s/--sitemap`, `-i/--include`, `-e/--exclude`, `-h/--help`, `--version` (now read from `package.json`), and the rule that `-i`/`-e` require `-s`.

**Breaking:** `-i`/`-e` no longer swallow bare words after the flag.

```bash
site-mapper -s main -i source1 source2   # was a 2-element list, now an error
site-mapper -s main -i source1 -i source2   # repeat the flag
site-mapper -s main -i source1,source2      # or use commas
```

`parseArgs` runs strict, so the old form fails loudly with usage text rather than silently doing something else:

```
Unexpected argument 'source2'. This command does not take positional arguments
```

Unknown options and a missing `-s` likewise exit 1 with usage instead of being ignored.

## Node floor: now >= 22

`engines` was `>=18`, which had not been accurate for some time. Worth stating plainly: **dev dependencies were never a reason to raise it** — they are not installed by consumers and have no bearing on the field. What constrains it is this package's own code plus its runtime dependencies.

yargs was the only runtime dependency narrowing the range (`^20.19.0 || ^22.12.0 || >=23`). With it gone:

| Source | Floor |
|---|---|
| `thread-stream` (via `pino`) | `>=20` — highest runtime dep |
| `util.parseArgs` in the CLI | stable as of Node 20 |
| everything else (`sax`, `split2`, `csv`, …) | `>=11` or lower |

So **20 is the technical minimum, and 22 is a support policy**: Node 18 and 20 both reached end of life (April 2025 and April 2026), and CI only exercises 22.x and 24.x. Declaring support for a runtime that is neither tested nor maintained is the weaker position.

README requirement and the sample `package.json` updated to match; the sample dependency now suggests `site-mapper >= 5.0.0`.

## Tests

Adds coverage for `--version`, both multi-value forms, `-i` without `-s`, and unknown options. Suite goes 38 → 43, all spawning the real binary. Lint clean.

README usage updated, including a note that the named sitemap keeps its configured settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
